### PR TITLE
Add Adafruit IO example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,25 @@ Run the Initial State example using the following command:
 sudo python2.7.9 initialstate_example.py
 ```
 
-<!-- meta-tags: vvv-e20, vvv-sn171, vvv-sn132, vvv-rf200, vvv-ek5100, vvv-snapconnect, vvv-initialstate, vvv-aws-iot, vvv-exosite, vvv-js, vvv-html, vvv-python, vvv-example -->
+## Adafruit IO Example
+### Python Requirements
+The application is written for Python 2.7. Install the required libraries into your Python environment as follows:
+
+```bash
+sudo pip2.7.9 install -r adafruitio/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
+```
+
+### Adafruit IO Requirements
+To use this example a free Adafruit IO account is required. To sign up, visit:
+https://accounts.adafruit.com/users/sign_up
+
+See [adafruitio/README.md](adafruitio/README.md) for instructions on how to set up your Adafruit IO account.
+
+### Running
+Run the Adafruit IO example using the following command:
+
+```bash
+sudo python2.7.9 adafruit_example.py
+```
+
+<!-- meta-tags: vvv-e20, vvv-sn171, vvv-sn132, vvv-rf200, vvv-ek5100, vvv-snapconnect, vvv-initialstate, vvv-aws-iot, vvv-exosite, vvv-adafruitio, vvv-js, vvv-html, vvv-python, vvv-example -->

--- a/adafruit_example.py
+++ b/adafruit_example.py
@@ -1,0 +1,6 @@
+from adafruitio.adafruit_connector import AdafruitConnector
+from snap_to_cloud import SNAPToCloudExample
+
+if __name__ == "__main__":
+    cloud_connector = AdafruitConnector()
+    SNAPToCloudExample(cloud_connector.publish)

--- a/adafruitio/README.md
+++ b/adafruitio/README.md
@@ -1,0 +1,37 @@
+![](https://cloud.githubusercontent.com/assets/1317406/12406044/32cd9916-be0f-11e5-9b18-1547f284f878.png)
+# E20 Example - Interfacing to Adafruit IO
+
+## Configuring Adafruit IO
+To use this example a free Adafruit IO account is required. To sign up, visit:
+
+> https://accounts.adafruit.com/users/sign_up
+
+After signing up, go to your [Adafruit IO settings page](https://io.adafruit.com/settings) and get your AIO API key:
+
+![](https://cloud.githubusercontent.com/assets/1317406/12931178/07558fe8-cf42-11e5-8f7f-f022f0209598.gif)
+
+## Setup Gateway
+Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).
+You must edit the provided `adafruitio/settings.py` file to use your personal AIO key:
+
+```python
+# TODO - Update ADAFRUIT_IO_KEY with your personal Adafruit IO API key
+ADAFRUIT_IO_KEY = "ab37939a9873db7e9f97b97a7ed99cb98d98e98baf98be98ad"
+```
+
+This example also uses several 3rd-party Python libraries. Install them onto your E20 using
+
+```bash
+sudo pip2.7.9 install -r adafruitio/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
+```
+
+Once both of these steps have been competed, execute the adafruit_example.py Python script as sudo.  
+
+```bash
+sudo python2.7.9 adafruit_example.py
+```
+
+Now that Adafruit IO and the E20 have been configured, 
+the [Feeds page](https://io.adafruit.com/feeds) should new values that were transmitted by the SNAP node.
+
+Now take some time to explore Adafruit IO by creating your own dashboards.

--- a/adafruitio/README.md
+++ b/adafruitio/README.md
@@ -1,6 +1,8 @@
 ![](https://cloud.githubusercontent.com/assets/1317406/12406044/32cd9916-be0f-11e5-9b18-1547f284f878.png)
 # E20 Example - Interfacing to Adafruit IO
 
+![](https://cloud.githubusercontent.com/assets/1317406/12931178/07558fe8-cf42-11e5-8f7f-f022f0209598.gif)
+
 ## Configuring Adafruit IO
 To use this example a free Adafruit IO account is required. To sign up, visit:
 
@@ -8,7 +10,7 @@ To use this example a free Adafruit IO account is required. To sign up, visit:
 
 After signing up, go to your [Adafruit IO settings page](https://io.adafruit.com/settings) and get your AIO API key:
 
-![](https://cloud.githubusercontent.com/assets/1317406/12931178/07558fe8-cf42-11e5-8f7f-f022f0209598.gif)
+![](https://cloud.githubusercontent.com/assets/1317406/12931309/b10b9b5e-cf42-11e5-84b0-901e029b340a.png)
 
 ## Setup Gateway
 Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).

--- a/adafruitio/adafruit_connector.py
+++ b/adafruitio/adafruit_connector.py
@@ -1,0 +1,23 @@
+from Adafruit_IO import *
+from settings import ADAFRUIT_IO_KEY
+
+from time import sleep
+
+
+class AdafruitConnector(object):
+    def __init__(self):
+        # Create an instance of the Adafruit IO REST client.
+        self.aio = Client(ADAFRUIT_IO_KEY)
+
+    def publish(self, thing_id, state):
+        """Publish a message to Adafruit IO REST API.
+
+        :param str thing_id: The 6-character SNAP MAC Address
+        :param dict state: A dictionary containing the new state values for a thing
+        """
+        print "Status update: ", thing_id
+        self.aio.send(thing_id + '-batt', int(state['batt']))
+        sleep(1)  # Pause for a second so we don't hit the API throttle limits
+        self.aio.send(thing_id + '-state', int(state['button_state']))
+        sleep(1)  # Pause for a second so we don't hit the API throttle limits
+        self.aio.send(thing_id + '-count', state['button_count'])

--- a/adafruitio/requirements.txt
+++ b/adafruitio/requirements.txt
@@ -1,0 +1,3 @@
+snapconnect>=3.4.3,<3.5
+tornado>=4.3
+adafruit-io>=1.0.2

--- a/adafruitio/settings.py
+++ b/adafruitio/settings.py
@@ -1,0 +1,2 @@
+# TODO - Update ADAFRUIT_IO_KEY with your personal Adafruit IO API key
+ADAFRUIT_IO_KEY = "xxxxxxxxxxxx"


### PR DESCRIPTION
I've added an example of using [Adafruit IO](https://io.adafruit.com/) to receive data collected from nodes. AIO allows for really simple dashboard creation and triggered events.

Example dashboard:
![](https://cloud.githubusercontent.com/assets/1317406/12931178/07558fe8-cf42-11e5-8f7f-f022f0209598.gif)