### PR TITLE
Move instructions for IoT services to their own READMEs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This example allows you to stand up a full "node to cloud" data monitoring solut
 - 1 x SN132 USB SNAP Stick
 - Synapse's Portal software
 - A cloud IoT service, like:
-    - Exosite's Portals
     - Amazon AWS IoT
+    - Adafruit IO
+    - Exosite's Portals
     - Initial State
 
 The application server for these examples uses the SNAP Connect Python library to communicate over a SNAP bridge
@@ -40,103 +41,22 @@ Copy the contents of this project's `snappyImages` directory to your `Portal/sna
 
 Now you can connect Portal to the SN132 as a bridge node and upload the `demo_sn171.py` script into the SN171s.
 
-Please make a note of the SNAP Addresses of the two SN171 nodes - you will need this information later
+Please make a note of the SNAP Addresses of the two SN171 nodes - you will need this information later.
 
 ## Install Python 2.7.9
 The E20 runs Ubuntu 14.04, which comes with Python 2.7.6 by default. Python 2.7.9 or later is required for interacting with 
 AWS IoT and Exosite, so we need to build it for the E20. If you do not already have Python 2.7.9 installed, clone this project
 onto the E20 and run ```sudo ./install-python2.7.9.sh``` to build and install it.
 
-## AWS IoT Example
-### Python Package Requirements
-Note: You must be using python 2.7.9+ in order to use this example.
+## Instructions for the Different Cloud Services
 
-Install the package dependencies:
+Follow the instructions contained in the README files in each cloud service's directory to get started:
 
-```bash
-sudo pip2.7.9 install -r aws_iot/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
-```
-
-### AWS Requirements
-An AWS developer account is required, your account must have full AWS IoT privileges. [Follow the instructions here to sign up for AWS.](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup)
-
-You must install and authenticate with AWS CLI, this is a python package that is installed when you install the Python
-requirements file.
-
-To authenticate your user with AWS, type ```/usr/local/lib/python2.7.9/bin/aws configure``` and specify your AWS Access Key ID, 
-AWS Secret Access Key, and region. For more information, see [Configuring the AWS Command Line Interface](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
-
-Update the ```THINGS``` variable in ```aws_iot/settings.py``` file to specify your device IDs (these need be the SNAP 
-addresses of your SN171 boards). Once you have updated this file, run ```python2.7.9 setup_aws.py``` from the ```aws_iot```
-directory to create your devices, policy, and certificate.
-
-### Running
-Run the AWS example using the following command:
-
-```bash
-sudo python2.7.9 aws_iot_example.py
-```
-
-## Exosite Example
-### Python Requirements
-The application is written for Python 2.7. Install the required libraries into your Python environment as follows:
-
-```bash
-sudo pip2.7.9 install -r exosite/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
-```
-
-### Exosite Requirements
-An Exosite "Portals" account is required. [Sign up for a free account here](https://portals.exosite.com/signup?plan=2692704445)
-
-See [exosite/README.md](exosite/README.md) for instructions on how to add devices to your Exosite "Portals" account.
-
-### Running
-Run the Exosite example using the following command:
-
-```bash
-sudo python2.7.9 exosite_example.py
-```
-
-## Initial State Example
-### Python Requirements
-The application is written for Python 2.7. Install the required libraries into your Python environment as follows:
-
-```bash
-sudo pip2.7.9 install -r initialstate/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
-```
-
-### Initial State Requirements
-To use this example a free Initial State login is required. To sign up, visit:
-https://www.initialstate.com/app#/register
-
-See [initialstate/README.md](initialstate/README.md) for instructions on how to set up your Initial State account.
-
-### Running
-Run the Initial State example using the following command:
-
-```bash
-sudo python2.7.9 initialstate_example.py
-```
-
-## Adafruit IO Example
-### Python Requirements
-The application is written for Python 2.7. Install the required libraries into your Python environment as follows:
-
-```bash
-sudo pip2.7.9 install -r adafruitio/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
-```
-
-### Adafruit IO Requirements
-To use this example a free Adafruit IO account is required. To sign up, visit:
-https://accounts.adafruit.com/users/sign_up
-
-See [adafruitio/README.md](adafruitio/README.md) for instructions on how to set up your Adafruit IO account.
-
-### Running
-Run the Adafruit IO example using the following command:
-
-```bash
-sudo python2.7.9 adafruit_example.py
-```
+| Cloud Service   | Instructions                                     |
+|-----------------|--------------------------------------------------|
+| Adafruit IO     | [adafruitio/README.md](adafruitio/README.md)     |
+| Amazon AWS IoT  | [aws_iot/README.md](aws_iot/README.md)           |
+| Exosite Portals | [exosite/README.md](exosite/README.md)           |
+| Initial State   | [initialstate/README.md](initialstate/README.md) |
 
 <!-- meta-tags: vvv-e20, vvv-sn171, vvv-sn132, vvv-rf200, vvv-ek5100, vvv-snapconnect, vvv-initialstate, vvv-aws-iot, vvv-exosite, vvv-adafruitio, vvv-js, vvv-html, vvv-python, vvv-example -->

--- a/adafruitio/README.md
+++ b/adafruitio/README.md
@@ -1,4 +1,5 @@
 [![](https://cloud.githubusercontent.com/assets/1317406/12406044/32cd9916-be0f-11e5-9b18-1547f284f878.png)](http://www.synapse-wireless.com/)
+
 # E20 Example - Interfacing to Adafruit IO
 
 ![](https://cloud.githubusercontent.com/assets/1317406/12931178/07558fe8-cf42-11e5-8f7f-f022f0209598.gif)

--- a/aws_iot/README.md
+++ b/aws_iot/README.md
@@ -1,0 +1,35 @@
+[![](https://cloud.githubusercontent.com/assets/1317406/12406044/32cd9916-be0f-11e5-9b18-1547f284f878.png)](http://www.synapse-wireless.com/)
+
+# E20 Example - Interfacing to Amazon AWS IoT
+
+## Configuring Amazon AWS IoT
+To use this example, an AWS developer account is required, and your account must have full AWS IoT privileges. To sign up, visit:
+
+> http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-set-up.html#cli-signup
+
+You must install and authenticate with AWS CLI; this is a Python package that is installed when you install the Python
+requirements file.
+
+## Setup Gateway
+**Note:** You must be using Python 2.7.9+ in order to use this example.
+
+Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).
+
+This example also uses several 3rd-party Python libraries. Install them onto your E20 using
+
+```bash
+sudo pip2.7.9 install -r aws_iot/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
+```
+
+To authenticate your user with AWS, type ```/usr/local/lib/python2.7.9/bin/aws configure``` and specify your AWS Access Key ID, 
+AWS Secret Access Key, and region. For more information, see [Configuring the AWS Command Line Interface](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html).
+
+Update the ```THINGS``` variable in ```aws_iot/settings.py``` file to specify your device IDs (these need be the SNAP 
+addresses of your SN171 boards). Once you have updated this file, run ```python2.7.9 setup_aws.py``` from the ```aws_iot```
+directory to create your devices, policy, and certificate.
+
+Run the AWS example using the following command:
+
+```bash
+sudo python2.7.9 aws_iot_example.py
+```

--- a/exosite/README.md
+++ b/exosite/README.md
@@ -1,8 +1,9 @@
 [![](https://cloud.githubusercontent.com/assets/1317406/12406044/32cd9916-be0f-11e5-9b18-1547f284f878.png)](http://www.synapse-wireless.com/)
+
 # E20 Example - Interfacing to Exosite's "Portals"
 
 ## Configuring Exosite Portals
-To use this example a free Exosite Portal is required. To sign up visit:
+To use this example, a free Exosite Portal is required. To sign up, visit:
 
 > https://portals.exosite.com/signup?plan=2692704445
 
@@ -24,9 +25,9 @@ Click the newly added SN171 device and its details should be displayed:
  
 In the "Alias" text box, fill in the SNAP address of the module that is installed in the first SN171 board.
 
-**NOTE** - to be compatible with the main.py example code, the addresses should be entered without any separators (no "." Or ":", etc.) plus the hexadecimal digits a-f must be entered in lower case.
+**NOTE** - to be compatible with the example code, the addresses should be entered without any separators (no "." Or ":", etc.) plus the hexadecimal digits a-f must be entered in lower case.
 
-Where the CIK value is displayed, copy this somewhere for later pasting into the CIK dictionary in main.py.
+Where the CIK value is displayed, copy this somewhere for later pasting into the CIK dictionary in exosite_connector.py.
 
 Next choose "Add Data" to define the information the SNAP node will be sending. 
 In the "Data Setup" dialog that is displayed, fill in the values:
@@ -52,7 +53,7 @@ Submit this form and add two more data sources:
     "Alias" = state
 
 ## Setup Gateway
-Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).  You must edit the provided main.py file to change the EXOSITE_CIKS dictionary to match your SN171 MAC addresses and Exosite CIKs. Find the following code snippet and update it:
+Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).  You must edit the provided exosite_connector.py file to change the EXOSITE_CIKS dictionary to match your SN171 MAC addresses and Exosite CIKs. Find the following code snippet and update it:
 
 ```python
 # TODO: Replace these with values from your own Exosite account and resource
@@ -64,13 +65,13 @@ EXOSITE_CIKS = {"XXXXXX": 'unique Exosite CIK here',
 This example also uses several 3rd-part Python libraries. Install them onto your E20 using
 
 ```bash
-sudo pip2.7.9 install -r requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
+sudo pip2.7.9 install -r exosite/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
 ```
 
-Once both of these steps have been competed, execute the main.py Python script as sudo.  
+Once both of these steps have been competed, execute the exosite_example.py Python script as sudo.  
 
 ```bash
-sudo python2.7.9 main.py
+sudo python2.7.9 exosite_example.py
 ```
 
 Now that Exosite and the E20 have been configured, refreshing the "Device Information" on the Exosite website should show new values that were transmitted by the SNAP node.

--- a/initialstate/README.md
+++ b/initialstate/README.md
@@ -1,9 +1,11 @@
 [![](https://cloud.githubusercontent.com/assets/1317406/12406044/32cd9916-be0f-11e5-9b18-1547f284f878.png)](http://www.synapse-wireless.com/)
+
 # E20 Example - Interfacing to Initial State
 
 ## Configuring Initial State
-To use this example a free Initial State login is required. To sign up visit:
-https://www.initialstate.com/app#/register
+To use this example, a free Initial State login is required. To sign up, visit:
+
+> https://www.initialstate.com/app#/register
 
 From the welcome screen choose Create HTTPS Bucket:
 
@@ -11,7 +13,7 @@ From the welcome screen choose Create HTTPS Bucket:
  
 In the form that appears you can choose any name that you wish for the bucket. A possibility would be to use the node's SNAP address.
 
-Once the bucket has been created you will need to copy the bucket key and access key from the settings panel into the dictionary in main.py. To access the settings click on the settings link:
+Once the bucket has been created you will need to find your Bucket and Access keys. To access these keys, click on the settings link:
 
 ![](https://cloud.githubusercontent.com/assets/1317406/12657827/162c6cce-c5cb-11e5-97ab-73675f626050.png)
  
@@ -19,10 +21,10 @@ You should see a panel like this:
 
 ![](https://cloud.githubusercontent.com/assets/1317406/12657839/1b091ff8-c5cb-11e5-86f2-0931295fc192.png)
 
-Copy the "Bucket Key" and "Access Key" into the main.py script.
+Copy the "Bucket Key" and "Access Key" somewhere for later pasting into initialstate_connector.py.
 
 ## Setup Gateway
-Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).  You must edit the provided main.py file to change the INITIAL_STATE_BUCKETS dictionary to match your SN171 MAC addresses and Initial State keys. Find the following code snippet and update it:
+Simply power up the E20 and load the software onto the E20 (put it in the snap user directory).  You must edit the provided initialstate_connector.py file to change the INITIAL_STATE_BUCKETS dictionary to match your SN171 MAC addresses and Initial State keys. Find the following code snippet and update it:
 
 ```python
 # TODO: Replace these with values from your own Initial State account and buckets
@@ -37,10 +39,10 @@ ACCESS_KEY = "your unique access key here"
 This example also uses several 3rd-part Python libraries. Install them onto your E20 using
 
 ```bash
-sudo pip2.7.9 install -r requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
+sudo pip2.7.9 install -r initialstate/requirements.txt --extra-index-url https://update.synapse-wireless.com/pypi/
 ```
 
-Once both of these steps have been competed, execute the main.py Python script as sudo.  
+Once both of these steps have been competed, execute the initialstate_example.py Python script as sudo.  
 
 ```bash
 sudo python2.7.9 initialstate_example.py


### PR DESCRIPTION
Moved the cloud-provider-specific instructions into each provider's own README, per @AlexMabry's recommendation.

If this looks good to you, @AlexMabry, you can go ahead and accept and merge this in!